### PR TITLE
redact gendered words

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,5 +1,7 @@
 # https://www.playframework.com/documentation/latest/Configuration
 
+include "redactedwords"
+
 play.application.loader = "wiring.AppLoader"
 
 play.filters.headers.contentSecurityPolicy = "img-src data: 'self'"

--- a/conf/redactedwords.conf
+++ b/conf/redactedwords.conf
@@ -1,0 +1,4 @@
+
+redact.genderedwords.list = ["she", "her", "hers", "girl", "girls", "woman", "women", "lady", "female", "he", "him", "his", "boy", "boys", "man", "men"]
+
+redact.petnames.list = ["jonny", "jamie", "bob", "dave"]


### PR DESCRIPTION
Co-authored-by: Yusuf Faraji <yusuf.faraji@guardian.co.uk>

## What does this change?
Adds a list of gendered words to a config file which allows these words to be redacted from the CVs. The list can be added to easily as new words are discovered.

## How to test
Run the branch locally and test on a CV containing e.g. "St Augustine's School for Girls", and "Girls" should be redacted.

## How can we measure success?
Fewer gendered words will make it through CV redaction, and thus allow CVs to be reviewed with minimal bias.

