### PR TITLE
Add greedy name regex to catch names in usernames etc

### DIFF
--- a/app/redact/PdfRedactor.scala
+++ b/app/redact/PdfRedactor.scala
@@ -44,6 +44,8 @@ object PdfRedactor {
       found <- TextFinder.findString(document, name)
     } yield found
 
+    val regexedNames: List[FoundText] = names.flatMap(word => TextFinder.findStringsMatchingRegex(document, word))
+
     val redactedWords: List[FoundText] = redactStringsList.flatMap(word => TextFinder.findString(document, word))
 
     redactFoundText(
@@ -55,6 +57,7 @@ object PdfRedactor {
         TextFinder.findUrl(document),
         TextFinder.findWebsite(document, "github.com"),
         TextFinder.findWebsite(document, "linkedin.com"),
+        regexedNames,
       ).flatten
     )
 

--- a/app/redact/TextFinder.scala
+++ b/app/redact/TextFinder.scala
@@ -5,10 +5,18 @@ import org.apache.pdfbox.text.{PDFTextStripper, TextPosition}
 
 import scala.collection.mutable.ListBuffer
 import scala.util.matching.Regex
+import play.api.Logger
 
 case class FoundText(pageIndex: Int, x1: Float, y1: Float, x2: Float, y2: Float, text: String)
 
 object TextFinder {
+
+  def findStringsMatchingRegex(document: PDDocument, needle: String): List[FoundText] = {
+    val textFinder = new RegexFinder(s"${needle.toLowerCase()}".r)
+    textFinder.getText(document)
+    textFinder.locations.result()
+  }
+
   def findString(document: PDDocument, needle: String): List[FoundText] = {
     val textFinder = new TextFinder(needle)
     textFinder.getText(document)


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Added a greedy search for people's names to help redact any partial usage e.g Steve in SteveCodes gets redeacted for someone called Steve