### PR TITLE
move candidate name page to top of correct candidate cv

### DIFF
--- a/app/redact/TextFinder.scala
+++ b/app/redact/TextFinder.scala
@@ -86,7 +86,7 @@ class AnalyseCV() extends PDFTextStripper {
       id = m.group(3),
       jobText = m.group(4).trim,
       jobId = "",
-      firstPage = getCurrentPageNo - 1,
+      firstPage = getCurrentPageNo - 2,
       lastPage = getCurrentPageNo - 1
     )
   }
@@ -98,6 +98,7 @@ class AnalyseCV() extends PDFTextStripper {
     val last3Lines = fullRegex.findFirstMatchIn(slidingWindow.take(3).reverse.mkString(" ")).map(candidateFromMatch)
     val last2Lines = fullRegex.findFirstMatchIn(slidingWindow.take(2).reverse.mkString(" ")).map(candidateFromMatch)
     val last1Line = fullRegex.findFirstMatchIn(slidingWindow.take(1).reverse.mkString(" ")).map(candidateFromMatch)
+
 
     (last3Lines orElse last2Lines orElse last1Line, potentialCandidate) match {
       case (Some(newCandidate), _) =>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -11,6 +11,4 @@ play.http.secret.key="${APP_SECRET}"
 
 redacted-exact-strings.enabled = "true"
 greedy-name-match.enabled = "true"
-
-
-
+new-page-split-behaviour.enabled = "true"


### PR DESCRIPTION
Co-authored-by: Yusuf Faraji <yusuf.faraji@guardian.co.uk>

## What does this change?
Moves the candidate info line on one page into the correct candidate CV so that the name is redacted out correctly.
