### PR TITLE
Add ability to remove first covering page for each CV

### DIFF
--- a/app/redact/PdfRedactor.scala
+++ b/app/redact/PdfRedactor.scala
@@ -17,6 +17,7 @@ object PdfRedactor {
   
   val enableExactStringMatching = config.getBoolean("redacted-exact-strings.enabled")
   val enableGreedyNameMatching = config.getBoolean("greedy-name-match.enabled")
+  val enableNewPageSplittingAndDeletion = config.getBoolean("new-page-split-behaviour.enabled")
 
   val redactStringsList = config.getStringList("redact.genderedwords.list").asScala.toList
   val commonNames = config.getStringList("redact.petnames.list").asScala.toList
@@ -78,8 +79,11 @@ object PdfRedactor {
 
     ImageRedactor.redactImages(document)
 
+    removeFirstPage(document)
     document.save(destination)
   }
+
+  def removeFirstPage(document: PDDocument) = if (enableNewPageSplittingAndDeletion) document.removePage(0)
 
   def redactFoundText(document: PDDocument, redactions: List[FoundText]): Unit = {
     val allPages = document.getDocumentCatalog.getPages


### PR DESCRIPTION
Co-authored-by: TJ Silver <thalia.silver@guardian.co.uk>






## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
 
In this change we add the ability to remove the first covering page of each CV, if enabled