### PR TITLE
Avoid NPE for some PDFs

### DIFF
--- a/app/redact/ImageRedactor.scala
+++ b/app/redact/ImageRedactor.scala
@@ -19,7 +19,9 @@ object ImageRedactor {
         case image: PDImageXObject =>
           resources.put(name, Image.placeholder(image.getWidth, image.getHeight, document))
         case form: PDFormXObject =>
-          replaceImageObjects(form.getResources, document)
+          Option(form.getResources).foreach { resources =>
+            replaceImageObjects(resources, document)
+          }
       }
     }
   }


### PR DESCRIPTION
When tested my last PR, I noticed that some example PDFS I found on the internet failed due to `getResources` returning null.  This PRs handles that error, although it does mean that images in these PDFs are not redacted.