### PR TITLE
Upgrade Play Framework version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target
 /.project
 /.settings
 /RUNNING_PID
+project/project
+project/metals.sbt

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -16,6 +16,8 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class Application(cc: ControllerComponents) extends AbstractController(cc) {
 
+  val logger = Logger(this.getClass())
+
   implicit val ec = cc.executionContext
 
   def index() = Action { implicit request: Request[AnyContent] =>
@@ -79,7 +81,7 @@ class Application(cc: ControllerComponents) extends AbstractController(cc) {
               PdfRedactor.redact(doc, zos, splitName(candidate.firstName) ++ splitName(candidate.lastName))
               doc.close()
             } catch {
-              case e: Exception => Logger.error("Oops", e)
+              case e: Exception => logger.error("Oops", e)
             }
             zos.closeEntry()
           }

--- a/app/wiring/AppLoader.scala
+++ b/app/wiring/AppLoader.scala
@@ -11,11 +11,12 @@ class AppLoader extends ApplicationLoader {
   val enableExactStringMatching = config.getBoolean("redacted-exact-strings.enabled")
   val enableGreedyNameMatching = config.getBoolean("greedy-name-match.enabled")
   val enableNewPageSplittingAndDeletion = config.getBoolean("new-page-split-behaviour.enabled")
+  val logger = Logger(this.getClass())
 
-  Logger.info("Starting Application with the following configuration")
-  Logger.info(s"Exact Redacted Strings matching is set to: $enableExactStringMatching")
-  Logger.info(s"Greedy Candidate Name matching is set to: $enableGreedyNameMatching")
-  Logger.info(s"Alternative Page Splitting and Deleting Cover Page is set to: $enableNewPageSplittingAndDeletion")
+  logger.info("Starting Application with the following configuration")
+  logger.info(s"Exact Redacted Strings matching is set to: $enableExactStringMatching")
+  logger.info(s"Greedy Candidate Name matching is set to: $enableGreedyNameMatching")
+  logger.info(s"Alternative Page Splitting and Deleting Cover Page is set to: $enableNewPageSplittingAndDeletion")
 
 
   override def load(context: Context): Application = {

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.15"
 
 libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.6.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.13")


### PR DESCRIPTION
## What does this change?

This change is a version focused change, the only code changes to ensure that the app continues to run (in this case only the logging needed a small change)

Here we upgrade SBT to 1.6.1, Scala to 2.12.15 and Play to 2.8.13.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- `sbt run`
- Navigate to localhost:9000
- Load up a single CV downloaded from Taleo
- Run the redaction and check names, pronouns and some gendered words have been redacted
- Load up a group CV set from Taleo
- Run the redaction and check names, pronouns and some gendered words have bee redacted

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
