### PR TITLE
Remove broken image

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -3,7 +3,6 @@
 
 @main("Redact PDF") {
   <div class="form-container">
-  <img class="mb-4" src="https://getbootstrap.com/assets/brand/bootstrap-solid.svg" alt="" width="72" height="72">
   <h1 class="h1 mb-3 font-weight-normal">Redact PDF</h1>
     <h2 class="h4 mb-3 font-weight-normal">Name-blind recruitment</h2>
 


### PR DESCRIPTION
## What does this change?

Removes the image at the top of the page.  This was just the bootstrap logo, which didn't really make any sense.  It now returns 404s, making the page look a little broken.