### PR TITLE
Add native packaging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,16 @@
-name := """redact-pdf"""
+
+name := """cv-redact-tool"""
 organization := "com.gu"
 
 version := "1.0-SNAPSHOT"
-scalacOptions += "-deprecation"
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
+
+lazy val root = (project in file(".")).enablePlugins(PlayScala, JavaServerAppPackaging)
+
 
 scalaVersion := "2.13.8"
+scalacOptions += "-deprecation"
+
 
 libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
@@ -18,4 +22,28 @@ libraryDependencies ++= Seq(
 
 // Adds additional packages into conf/routes
 // play.sbt.routes.RoutesKeys.routesImport += "com.gu.binders._"
-   
+
+/* 
+   Packaging settings section
+
+   We are using sbt-native-packager to build a debian package.
+   The SBT settings below are used for the build of that package
+ */
+
+/* A debian package needs some mandatory settings to be valid */
+maintainer := "The Guardian engineering managers  <engineering.managers@theguardian.com>"
+packageSummary := "Online web app to redact cv"
+packageDescription := """"""
+
+/* While not mandatory it is still highly recommended to add relevant JRE package as a dependency */ 
+debianPackageDependencies := Seq("java11-runtime-headless")
+
+/* Configure the Java options with which the executable will be launched */
+javaOptions in Universal ++= Seq(
+    // -J params will be added as jvm parameters
+    "-J-Xmx2g",
+    "-J-Xms2g",
+)
+
+
+

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,11 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.17")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.11")
+
+/* 
+   The following is needed because scala-xml has not be updated to 2.x in sbt yet but has in sbt-native-packager 
+   See: https://github.com/scala/bug/issues/12632
+ */
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.13")
+
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.11")

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+sbt clean compile test debian:packageBin
+


### PR DESCRIPTION
## What does this change?

Use `sbt-native-packager` to build a Debian native package. 
This should integrate well with #20 which bring continuous integration
