### PR TITLE
Add infrastructure to continuous deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,29 +50,9 @@ jobs:
         uses: guardian/actions-riff-raff@v2
         with:
           projectName: 'Hiring & Onboarding Tools::CV Redact'
-          config: |
-            stacks:
-              - hiring-and-onboarding
-            regions:
-              - eu-west-1
-            allowedStages:
-              - PROD
-            deployments:
-              cv-redact-tool:
-                type: autoscaling
-                parameters:
-                  bucketSsmLookup: true
-                dependencies:
-                  - cv-redact-tool-ami-update    
-              cv-redact-tool-ami-update:
-                app: cv-redact-tool
-                type: ami-cloudformation-parameter
-                parameters:
-                  amiParameter: AMICvredacttool
-                  amiEncrypted: true
-                  amiTags:
-                    Recipe: arm64-bionic-java11-deploy-infrastructure
-                    AmigoStage: PROD
+          configPath: cdk/cdk.out/riff-raff.yaml
           contentDirectories: |
+            cdk.out:
+              - cdk/cdk.out
             cv-redact-tool:
               - target/cv-redact-tool.deb

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,9 +1,12 @@
 import 'source-map-support/register';
-import { App } from 'aws-cdk-lib';
+import { GuRootExperimental } from '@guardian/cdk/lib/experimental/constructs';
 import { CvRedactTool } from '../lib/cv-redact-tool';
 
-const app = new App();
+const app = new GuRootExperimental();
 new CvRedactTool(app, 'CvRedactTool-PROD', {
 	stack: 'hiring-and-onboarding',
 	stage: 'PROD',
+	env: {
+		region: 'eu-west-1',
+	},
 });

--- a/cdk/lib/cv-redact-tool.ts
+++ b/cdk/lib/cv-redact-tool.ts
@@ -49,6 +49,10 @@ export class CvRedactTool extends GuStack {
 				maximumInstances: 2,
 			},
 			applicationLogging: { enabled: true },
+			imageRecipe: {
+				Recipe: 'arm64-bionic-java11-deploy-infrastructure',
+				Encrypted: true,
+			},
 		});
 
 		new GuCname(this, 'cv-redact.gutools.co.uk - cert', {


### PR DESCRIPTION
> **Note**
> Builds on #33.

## What does this change?
Configures this project with a `cloudformation` Riff-Raff deployment, enabling CD of infrastructure. To achieve this, we switch to an [auto-generated `riff-raff.yaml`](https://github.com/guardian/cdk/blob/d50157ceb5f89cfa1b25cbe09d6da5cbd1d58edf/src/experimental/riff-raff-yaml-file/README.md).

<details>
<summary>riff-raff.yaml comparison</summary>

### Before
```yaml
stacks:
  - hiring-and-onboarding
regions:
  - eu-west-1
allowedStages:
  - PROD
deployments:
  cv-redact-tool:
    type: autoscaling
    parameters:
      bucketSsmLookup: true
    dependencies:
      - cv-redact-tool-ami-update    
  cv-redact-tool-ami-update:
    app: cv-redact-tool
    type: ami-cloudformation-parameter
    parameters:
      amiParameter: AMICvredacttool
      amiEncrypted: true
      amiTags:
        Recipe: arm64-bionic-java11-deploy-infrastructure
        AmigoStage: PROD
```

### After
```yaml
allowedStages:
  - PROD
deployments:
  asg-upload-eu-west-1-hiring-and-onboarding-cv-redact-tool:
    type: autoscaling
    actions:
      - uploadArtifacts
    regions:
      - eu-west-1
    stacks:
      - hiring-and-onboarding
    app: cv-redact-tool
    parameters:
      bucketSsmLookup: true
      prefixApp: true
    contentDirectory: cv-redact-tool
  cfn-eu-west-1-hiring-and-onboarding-cv-redact-tool:
    type: cloud-formation
    regions:
      - eu-west-1
    stacks:
      - hiring-and-onboarding
    app: cv-redact-tool
    contentDirectory: cdk.out
    parameters:
      templateStagePaths:
        PROD: CvRedactTool-PROD.template.json
      amiParametersToTags:
        AMICvredacttool:
          BuiltBy: amigo
          AmigoStage: PROD
          Recipe: arm64-bionic-java11-deploy-infrastructure
          Encrypted: 'true'
    dependencies:
      - asg-upload-eu-west-1-hiring-and-onboarding-cv-redact-tool
  asg-update-eu-west-1-hiring-and-onboarding-cv-redact-tool:
    type: autoscaling
    actions:
      - deploy
    regions:
      - eu-west-1
    stacks:
      - hiring-and-onboarding
    app: cv-redact-tool
    parameters:
      bucketSsmLookup: true
      prefixApp: true
    dependencies:
      - cfn-eu-west-1-hiring-and-onboarding-cv-redact-tool
    contentDirectory: cv-redact-tool
```
</details>

## How to test
  - Deploy this branch
  - Observe a CloudFormation deployment being performed by Riff-Raff, in addition to the autoscaling deployment

---

Fixes #22.
