### PR TITLE
Use developerPlayground-arm64-java11 as the AMI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
                   amiParameter: AMICvredacttool
                   amiEncrypted: true
                   amiTags:
-                    Recipe: arm64-bionic-java11-deploy-infrastructure
+                    Recipe: arm64-focal-java11-deploy-infrastructure
                     AmigoStage: PROD
           contentDirectories: |
             cv-redact-tool:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
                   amiParameter: AMICvredacttool
                   amiEncrypted: true
                   amiTags:
-                    Recipe: arm64-focal-java11-deploy-infrastructure
+                    Recipe: developerPlayground-arm64-java11
                     AmigoStage: PROD
           contentDirectories: |
             cv-redact-tool:

--- a/cdk/lib/cv-redact-tool.ts
+++ b/cdk/lib/cv-redact-tool.ts
@@ -50,7 +50,7 @@ export class CvRedactTool extends GuStack {
 			},
 			applicationLogging: { enabled: true },
 			imageRecipe: {
-				Recipe: 'arm64-bionic-java11-deploy-infrastructure',
+				Recipe: 'developerPlayground-arm64-java11',
 				Encrypted: true,
 			},
 		});


### PR DESCRIPTION
## What does this change?

Move to use https://amigo.gutools.co.uk/recipes/developerPlayground-arm64-java11.

This will allow us to:

- Move redact-pdf to 22.04 to avoid the 18.04 EOL

## How to test

Deploy this PR to the PROD environment (**there is no CODE**) and check the EC2 instances with the new AMI are successfully brought into service & that we can access the redact-pdf tool.

## How can we measure success?

Can we use the focal AMI to successfully deploy Janus?

## Have we considered potential risks?

Janus is not deployable with Focal base AMIs, we'll revert.