### PR TITLE
Update the AMIgo recipe used

### DIFF
--- a/cdk/lib/cv-redact-tool.ts
+++ b/cdk/lib/cv-redact-tool.ts
@@ -47,7 +47,7 @@ export class CvRedactTool extends GuStack {
 			},
 			applicationLogging: { enabled: true },
 			imageRecipe: {
-				Recipe: 'developerPlayground-arm64-java21',
+				Recipe: 'arm64-java21',
 				Encrypted: true,
 			},
 		});


### PR DESCRIPTION
## What does this change?
This service has been moved to the hiring and onboarding AWS account. For clarity, update the AMI recipe name, removing "developerPlayground".

This application seems to be the only [consumer of the `developerPlayground-arm64-java21` recipe](https://amigo.gutools.co.uk/recipes/developerPlayground-arm64-java21/usages), so I think we can delete it once this PR is merged.

Other services can still make use of the more generically named [arm64-java21 recipe](https://amigo.gutools.co.uk/recipes/arm64-java21) by creating an encrypted copy into their account.

## How to test
Once a bake of the new recipe is available, [deploy](https://riffraff.gutools.co.uk/deployment/view/caa91fa4-9c40-426a-9243-09b534465699) this branch. It should deploy successfully.

Riff-Raff's deployment logs shows the AMI from the recipe being used:

<img width="1080" alt="image" src="https://github.com/guardian/redact-pdf/assets/836140/2da310a5-fc6e-4561-b8b1-1166260b72d2">
