### PR TITLE
chore(ci): Remove redundant GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure private infra config credentials
-        uses: guardian/actions-read-private-repos@v0.1.0
-        with:
-          private-ssh-keys: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
-
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## What does this change?
The GitHub Action [`guardian/actions-read-private-repos`](https://github.com/guardian/actions-read-private-repos) with an input of `secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY` is used for https://github.com/guardian/private-infrastructure-config.

`@guardian/private-infrastructure-config` [isn't listed as a dependency in the repository](https://github.com/search?q=repo%3Aguardian%2Fredact-pdf%20private-infrastructure-config&type=code), therefore this action is redundant and can be removed.